### PR TITLE
remove internal implementation of longestCommonSubsequence

### DIFF
--- a/src/main/java/io/github/bsonpatch/InternalUtils.java
+++ b/src/main/java/io/github/bsonpatch/InternalUtils.java
@@ -23,8 +23,6 @@ import org.bson.BsonArray;
 import org.bson.BsonValue;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 class InternalUtils {
@@ -38,40 +36,4 @@ class InternalUtils {
         return toReturn;
     }
 
-    static List<BsonValue> longestCommonSubsequence(final List<BsonValue> a, final List<BsonValue> b) {
-        if (a == null || b == null) {
-            throw new NullPointerException("List must not be null for longestCommonSubsequence");
-        }
-
-        List<BsonValue> toReturn = new LinkedList<BsonValue>();
-
-        int aSize = a.size();
-        int bSize = b.size();
-        int temp[][] = new int[aSize + 1][bSize + 1];
-
-        for (int i = 1; i <= aSize; i++) {
-            for (int j = 1; j <= bSize; j++) {
-                if (i == 0 || j == 0) {
-                    temp[i][j] = 0;
-                } else if (a.get(i - 1).equals(b.get(j - 1))) {
-                    temp[i][j] = temp[i - 1][j - 1] + 1;
-                } else {
-                    temp[i][j] = Math.max(temp[i][j - 1], temp[i - 1][j]);
-                }
-            }
-        }
-        int i = aSize, j = bSize;
-        while (i > 0 && j > 0) {
-            if (a.get(i - 1).equals(b.get(j - 1))) {
-                toReturn.add(a.get(i - 1));
-                i--;
-                j--;
-            } else if (temp[i - 1][j] > temp[i][j - 1])
-                i--;
-            else
-                j--;
-        }
-        Collections.reverse(toReturn);
-        return toReturn;
-    }
 }


### PR DESCRIPTION
Back in 2019, the usage of this method in BsonDiff was changed to use the commons-collections4 ListUtils version.  There are no other usages of this internal, package-visible static method.  So, I'm removing it from the code base.  It's been six years, if we haven't found a use for it in that time, we probably never will.  Removing increases unit test line coverage from 91% to 94% :-)